### PR TITLE
Adding safety check to Streamlet

### DIFF
--- a/MCStreamlet.cfg
+++ b/MCStreamlet.cfg
@@ -1,13 +1,15 @@
 SPECIFICATION Spec
 \* Add statements after this line.
-CONSTANT n1 = n1
-CONSTANT n2 = n2
-CONSTANT n3 = n3
-CONSTANT n4 = n4
-CONSTANT CorrectNodes <- ConstCorrectNodes
-CONSTANT FaultyNodes <- ConstFaultyNodes
-CONSTANT Leaders <- ConstLeaders
-CONSTANT GlobalStabTime = 1
+CONSTANT 
+    h1 = h1
+    h2 = h2
+    h3 = h3
+    a1 = a1
+    CorrectNodes <- ConstCorrectNodes
+    FaultyNodes <- ConstFaultyNodes
+    Leaders <- ConstLeaders
+    GlobalStabTime = 2
 SYMMETRY NodePerms
-PROPERTY Liveness
-INVARIANT TypeInvariant
+
+INVARIANT TypeInvariant PartialSynchrony
+PROPERTY MonoIncEpoch LocalEpochCorrectness NoDoubleVotePerEpoch

--- a/MCStreamlet.cfg
+++ b/MCStreamlet.cfg
@@ -12,4 +12,4 @@ CONSTANT
 SYMMETRY NodePerms
 
 INVARIANT TypeInvariant PartialSynchrony
-PROPERTY MonoIncEpoch LocalEpochCorrectness NoDoubleVotePerEpoch
+PROPERTY MonoIncEpoch LocalEpochCorrectness NoDoubleVotePerEpoch Consistency

--- a/MCStreamlet.cfg
+++ b/MCStreamlet.cfg
@@ -8,7 +8,7 @@ CONSTANT
     CorrectNodes <- ConstCorrectNodes
     FaultyNodes <- ConstFaultyNodes
     Leaders <- ConstLeaders
-    GlobalStabTime = 2
+    GlobalStabTime = 3
 SYMMETRY NodePerms
 
 INVARIANT TypeInvariant PartialSynchrony

--- a/MCStreamlet.tla
+++ b/MCStreamlet.tla
@@ -3,11 +3,11 @@ EXTENDS Streamlet, TLC
 
 CONSTANTS h1, h2, h3, a1
 
-ConstCorrectNodes == {h1, h2}
-ConstFaultyNodes == {a1}
+ConstCorrectNodes == {h1, h2, h3}
+ConstFaultyNodes == {}
 NodePerms == Permutations(ConstCorrectNodes) \cup Permutations(ConstFaultyNodes)
 
-ConstLeaders == <<h2, a1, h1>>
+ConstLeaders == <<h2, h1, h3, h1>>
 
 \* for debugging purposes: copy from error trace then paste here, and uncomment the ASSUME PrintT statements: 
 localBlocksTest == (

--- a/MCStreamlet.tla
+++ b/MCStreamlet.tla
@@ -1,12 +1,12 @@
 ---- MODULE MCStreamlet ----
 EXTENDS Streamlet, TLC
 
-CONSTANTS n1, n2, n3, n4
+CONSTANTS h1, h2, h3, a1
 
-ConstCorrectNodes == {n1, n2}
-ConstFaultyNodes == {n3}
+ConstCorrectNodes == {h1, h2}
+ConstFaultyNodes == {a1}
 NodePerms == Permutations(ConstCorrectNodes) \cup Permutations(ConstFaultyNodes)
 
-ConstLeaders == <<n2, n3, n1>>
+ConstLeaders == <<h2, a1, h1>>
 
 =============================================================================

--- a/MCStreamlet.tla
+++ b/MCStreamlet.tla
@@ -9,4 +9,16 @@ NodePerms == Permutations(ConstCorrectNodes) \cup Permutations(ConstFaultyNodes)
 
 ConstLeaders == <<h2, a1, h1>>
 
+\* for debugging purposes: copy from error trace then paste here, and uncomment the ASSUME PrintT statements: 
+localBlocksTest == (
+    h1 :> {[epoch |-> 0, id |-> 0, length |-> 0, parent |-> 0, sigs |-> {h1, h2, a1}], [epoch |-> 1, id |-> 1, length |-> 1, parent |-> 0, sigs |-> {h1, h2}], [epoch |-> 2, id |-> 2, length |-> 2, parent |-> 1, sigs |-> {h1, a1}]} @@
+    h2 :> {[epoch |-> 0, id |-> 0, length |-> 0, parent |-> 0, sigs |-> {h1, h2, a1}], [epoch |-> 1, id |-> 1, length |-> 1, parent |-> 0, sigs |-> {h2, a1}], [epoch |-> 2, id |-> 2, length |-> 2, parent |-> 1, sigs |-> {h2, a1}]} @@ 
+    a1 :> {[epoch |-> 0, id |-> 0, length |-> 0, parent |-> 0, sigs |-> {h1, h2, a1}], [epoch |-> 1, id |-> 1, length |-> 1, parent |-> 0, sigs |-> {h2, a1}], [epoch |-> 2, id |-> 2, length |-> 2, parent |-> 1, sigs |-> {a1}]})
+\* ASSUME PrintT(FinalizedBlocks(localBlocksTest[h1]))
+\* ASSUME PrintT(FinalizedBlocks(localBlocksTest[h2]))
+\* ASSUME PrintT(FinalizedBlocks(localBlocksTest[a1]))
+
+chain1 == FinalizedBlocks(localBlocksTest[h1])
+chain2 == FinalizedBlocks(localBlocksTest[h2])
+\* ASSUME PrintT(IsPrefixedChain(chain1, chain2))
 =============================================================================


### PR DESCRIPTION
Currently I have made the following improvements:

- add more code comments, properly indent all code blocks.
- add `id` field to `BlockType` to distinguish different block proposed in the same epoch 
  - this is necessary to express the `NoDoubleVotePerEpoch` property (as the paper suggested that node should vote for the _first_ proposal heard from the leader)
- switch `i` counter to `localEpoch` for better readability (I have tested out its correctness in [02f1597](https://github.com/kshehata/streamlet_tla/commit/02f15979df848deae02c970d5d1608db03aa2531) before merging into `Streamlet.tla` so I'm fairly confident it's equivalent to your PartialSync code, just more understandable IMHO. )
- add properties like `PartialSynchrony`, `LocalEpochCorrectness` etc. 
- added `Consistency` rule directly reflecting the non-conflicting finalized chain between any two honest replicas from Theorem 3 of the paper.

- [x] Adding safety properties regarding finalized blocks 