### PR TITLE
Message and Block struct refactoring

### DIFF
--- a/MCStreamlet.cfg
+++ b/MCStreamlet.cfg
@@ -5,6 +5,7 @@ CONSTANT
     h2 = h2
     h3 = h3
     a1 = a1
+    TrustedCreator = TrustedCreator
     CorrectNodes <- ConstCorrectNodes
     FaultyNodes <- ConstFaultyNodes
     Leaders <- ConstLeaders


### PR DESCRIPTION
I tried to refactor our block struct (so that `block.creator` is only a single node, prev: `block.sigs: SUBSET(Nodes)`) and our message struct (so that `msg.vote: Node` and `msg.block` is always never updated).

However, the number of states seem even worse:
<img width="716" alt="Screenshot 2022-11-10 at 5 27 53 PM" src="https://user-images.githubusercontent.com/20514086/201058604-fd36640c-2afb-48fc-9684-28ffeadd5538.png">

than our current approach:
<img width="686" alt="Screenshot 2022-11-10 at 5 33 56 PM" src="https://user-images.githubusercontent.com/20514086/201058677-48f67f2a-36b6-4966-971c-cb42a0b3bff9.png">
